### PR TITLE
Fix %remote-call 

### DIFF
--- a/cl-nglview/widget.lisp
+++ b/cl-nglview/widget.lisp
@@ -1246,11 +1246,11 @@ kwargs=kwargs2)
   (let (msg)
     (let ((component-index (assoc "component_index" kwargs :test #'string=)))
       (when component-index
-        (push component-index msg)
+        (push (cons "component_index" component-index) msg)
         (setf kwargs (remove component-index kwargs))))
     (let ((repr-index (assoc "repr_index" kwargs :test #'string=)))
       (when repr-index
-        (push repr-index msg)
+        (push (cons "repr_index" repr-index) msg)
         (setf kwargs (remove repr-index kwargs))))
     (push (cons "target" target) msg)
     (push (cons "type" "call_method") msg)


### PR DESCRIPTION
It appears that only the values of `component_index` and `repl_index` are added to the message in `%remote-call`. Should be a cons cell with the tag name. Python code below for reference.

https://github.com/clasp-developers/cl-nglview/blob/ef9a64ea749af608a0858bdbcf2f57d5be30200f/nglview/widget.py#L1291-L1294